### PR TITLE
Add ghost piece to visualize landing spot

### DIFF
--- a/public/tetris.js
+++ b/public/tetris.js
@@ -108,6 +108,7 @@ function draw() {
 
   drawGrid();
   drawMatrix(arena, { x: 0, y: 0 });
+  drawGhost();
   drawMatrix(player.matrix, player.pos);
 }
 
@@ -120,6 +121,26 @@ function drawMatrix(matrix, offset) {
       }
     });
   });
+}
+
+function calculateGhostPosition() {
+  const ghost = {
+    pos: { x: player.pos.x, y: player.pos.y },
+    matrix: player.matrix
+  };
+  while (!collide(arena, ghost)) {
+    ghost.pos.y++;
+  }
+  ghost.pos.y--;
+  return ghost.pos;
+}
+
+function drawGhost() {
+  const pos = calculateGhostPosition();
+  context.save();
+  context.globalAlpha = 0.3;
+  drawMatrix(player.matrix, pos);
+  context.restore();
 }
 
 function drawGrid() {


### PR DESCRIPTION
## Summary
- show a shadow of the current piece at its predicted landing position

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68497742ddb8832a9f276b4af95f2ec1